### PR TITLE
move owner check down to credential

### DIFF
--- a/src/containers/orgs/OrgDetailsContainer.js
+++ b/src/containers/orgs/OrgDetailsContainer.js
@@ -182,14 +182,6 @@ class OrgDetailsContainer extends Component<Props, State> {
   renderIntegrationSegment = () => {
 
     const { isOwner, org } = this.props;
-    if (!isOwner) {
-      return null;
-    }
-
-    const integration :Map = org.get('integration', Map());
-    if (integration.isEmpty()) {
-      return null;
-    }
 
     return (
       <CardSegment noBleed vertical>

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -163,8 +163,8 @@ class OrgIntegrationSection extends Component<Props, State> {
           isVisible={isVisibleGenerateConfigModal}
           onClickPrimary={this.handleOnClickGenerate}
           onClose={this.closeModal}
-          textPrimary='Generate'
-          textTitle='Generate Integration Configuration File'
+          textPrimary="Generate"
+          textTitle="Generate Integration Configuration File"
           viewportScrolling>
         <Form
             formData={formData.toJS()}
@@ -197,6 +197,7 @@ renderDatabaseCredentials = () => {
   }
 
   const integration: Map = org.get('integration', Map());
+  
   if (integration.isEmpty()) {
     return null;
   }
@@ -213,8 +214,8 @@ renderDatabaseCredentials = () => {
           <ActionControlWithButton>
             <Input
                 disabled
-                type='password'
-                value='********************************'
+                type="password"
+                value="********************************"
             />
             <CopyButton onClick={this.handleOnClickCopyCredential} />
           </ActionControlWithButton>
@@ -222,23 +223,23 @@ renderDatabaseCredentials = () => {
       </SectionGrid>
       <SectionGrid columns={2}>
         <div>
-          <Button mode='primary' onClick={this.openModal}>
+          <Button mode="primary" onClick={this.openModal}>
             Generate Integration Configuration File
           </Button>
         </div>
       </SectionGrid>
       {this.renderGenerateConfigModal()}
-    </>
-    );
-  };
+  </>
+  );
+};
 
-  render() {
-    return (
-      <>
-        {this.renderDatabaseUrl()}
-        {this.renderDatabaseCredentials()}
-    </>
-    );
+render() {
+  return (
+    <>
+      {this.renderDatabaseUrl()}
+      {this.renderDatabaseCredentials()}
+  </>
+  );
   }
 }
 

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -7,7 +7,10 @@ import React, { Component } from 'react';
 import { Map, fromJS } from 'immutable';
 import { Form } from 'lattice-fabricate';
 import {
-  Button, CopyButton, Input, Modal
+  Button,
+  CopyButton,
+  Input,
+  Modal,
 } from 'lattice-ui-kit';
 
 import DBMSTypes from '../../../utils/integration-config/DBMSTypes';
@@ -22,33 +25,33 @@ const dataSchema = {
       properties: {
         targetServer: {
           title: 'Target Server',
-          type: 'string'
+          type: 'string',
         },
         targetDatabase: {
           title: 'Target Database',
-          type: 'string'
+          type: 'string',
         },
         targetDBMS: {
           enum: Object.keys(DBMSTypes),
           title: 'Target DBMS',
-          type: 'string'
+          type: 'string',
         },
         targetPort: {
           title: 'Target Port',
-          type: 'number'
-        }
+          type: 'number',
+        },
       },
       title: '',
-      type: 'object'
-    }
+      type: 'object',
+    },
   },
   title: '',
-  type: 'object'
+  type: 'object',
 };
 
 const uiSchema = {
   fields: {
-    classNames: 'column-span-12'
+    classNames: 'column-span-12',
   }
 };
 
@@ -57,54 +60,58 @@ const INITIAL_FORM_DATA = fromJS({
     targetDBMS: '',
     targetDatabase: '',
     targetPort: 5432,
-    targetServer: ''
+    targetServer: '',
   }
 });
 
 type FormData = {
-  fields:{
-    targetDBMS:?string,
-    targetDatabase:?string,
-    targetPort:?number,
-    targetServer:?string
-  }
+  fields :{
+    targetDBMS :?string;
+    targetDatabase :?string;
+    targetPort :?number;
+    targetServer :?string;
+  };
 };
 
 type Props = {
-  isOwner:boolean,
-  org:Map
+  isOwner :boolean;
+  org :Map;
 };
 
 type State = {
-  formData:Map,
-  isVisibleGenerateConfigModal:boolean
+  formData :Map;
+  isVisibleGenerateConfigModal :boolean;
 };
 
 class OrgIntegrationSection extends Component<Props, State> {
-  constructor(props:Props) {
+
+  constructor(props :Props) {
+
     super(props);
 
     this.state = {
       formData: INITIAL_FORM_DATA,
-      isVisibleGenerateConfigModal: false
+      isVisibleGenerateConfigModal: false,
     };
   }
 
-  handleOnChangeForm = ({ formData }:{ formData:FormData }) => {
+  handleOnChangeForm = ({ formData } :{ formData :FormData }) => {
+
     const { formData: stateFormData } = this.state;
 
     let newFormData = fromJS(formData);
     if (isNonEmptyString(formData.fields.targetDBMS)) {
       if (stateFormData.getIn(['fields', 'targetDBMS']) !== newFormData.getIn(['fields', 'targetDBMS'])) {
-        const dbms:Object = DBMSTypes[formData.fields.targetDBMS];
+        const dbms :Object = DBMSTypes[formData.fields.targetDBMS];
         newFormData = newFormData.setIn(['fields', 'targetPort'], dbms.port);
       }
     }
 
     this.setState({ formData: newFormData });
-  };
+  }
 
   handleOnClickCopyCredential = () => {
+
     const { isOwner, org } = this.props;
 
     if (isOwner) {
@@ -113,9 +120,10 @@ class OrgIntegrationSection extends Component<Props, State> {
         navigator.clipboard.writeText(org.getIn(['integration', 'credential'], ''));
       }
     }
-  };
+  }
 
   handleOnClickGenerate = () => {
+
     const { org } = this.props;
     const { formData } = this.state;
 
@@ -127,24 +135,27 @@ class OrgIntegrationSection extends Component<Props, State> {
       targetDatabase: formData.getIn(['fields', 'targetDatabase']),
       targetPort: formData.getIn(['fields', 'targetPort']),
       targetServer: formData.getIn(['fields', 'targetServer']),
-      targetDBMS: formData.getIn(['fields', 'targetDBMS'])
+      targetDBMS: formData.getIn(['fields', 'targetDBMS']),
     });
-  };
+  }
 
   closeModal = () => {
+
     this.setState({
       formData: INITIAL_FORM_DATA,
-      isVisibleGenerateConfigModal: false
+      isVisibleGenerateConfigModal: false,
     });
-  };
+  }
 
   openModal = () => {
+
     this.setState({
-      isVisibleGenerateConfigModal: true
+      isVisibleGenerateConfigModal: true,
     });
-  };
+  }
 
   renderGenerateConfigModal = () => {
+
     const { formData, isVisibleGenerateConfigModal } = this.state;
 
     return (
@@ -164,68 +175,71 @@ class OrgIntegrationSection extends Component<Props, State> {
             uiSchema={uiSchema} />
       </Modal>
     );
-  };
-  renderDatabaseUrl = () => {
-    const { org } = this.props;
-    const orgIdClean = org.get('id').replace(/-/g, '');
-
-    return (
-      <SectionGrid>
-        <h2>Database Details</h2>
-        <h5>JDBC URL</h5>
-        <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
-      </SectionGrid>
-    );
-  };
-
-  renderDatabaseCredentials = () => {
-    const { isOwner, org } = this.props;
-
-    if (!isOwner) {
-      return null;
-    }
-
-    const integration:Map = org.get('integration', Map());
-
-    if (integration.isEmpty()) {
-      return null;
-    }
-
-    return (
-      <>
-        <SectionGrid>
-          <h5>USER</h5>
-          <pre>{org.getIn(['integration', 'user'], '')}</pre>
-          <h5>CREDENTIAL</h5>
-        </SectionGrid>
-        <SectionGrid columns={2}>
-          <div style={{ marginTop: '4px' }}>
-            <ActionControlWithButton>
-              <Input disabled type="password" value="********************************" />
-              <CopyButton onClick={this.handleOnClickCopyCredential} />
-            </ActionControlWithButton>
-          </div>
-        </SectionGrid>
-        <SectionGrid columns={2}>
-          <div>
-            <Button mode="primary" onClick={this.openModal}>
-              Generate Integration Configuration File
-            </Button>
-          </div>
-        </SectionGrid>
-        {this.renderGenerateConfigModal()}
-      </>
-    );
-  };
-
-  render() {
-    return (
-      <>
-        {this.renderDatabaseUrl()}
-        {this.renderDatabaseCredentials()}
-      </>
-    );
   }
+renderDatabaseUrl = () => {
+  const { org } = this.props;
+  const orgIdClean = org.get('id').replace(/-/g, '');
+
+  return (
+    <SectionGrid>
+      <h2>Database Details</h2>
+      <h5>JDBC URL</h5>
+      <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
+    </SectionGrid>
+  );
+};
+
+renderDatabaseCredentials = () => {
+  const { isOwner, org } = this.props;
+
+  if (!isOwner) {
+    return null;
+  }
+
+  const integration:Map = org.get('integration', Map());
+
+  if (integration.isEmpty()) {
+    return null;
+  }
+
+  return (
+    <>
+      <SectionGrid>
+        <h5>USER</h5>
+        <pre>{org.getIn(['integration', 'user'], '')}</pre>
+        <h5>CREDENTIAL</h5>
+      </SectionGrid>
+      <SectionGrid columns={2}>
+        <div style={{ marginTop: '4px' }}>
+          <ActionControlWithButton>
+            <Input
+                disabled
+                type="password"
+                value="********************************" />
+            <CopyButton onClick={this.handleOnClickCopyCredential} />
+          </ActionControlWithButton>
+        </div>
+      </SectionGrid>
+      <SectionGrid columns={2}>
+        <div>
+          <Button mode="primary" onClick={this.openModal}>
+            Generate Integration Configuration File
+          </Button>
+        </div>
+      </SectionGrid>
+      {this.renderGenerateConfigModal()}
+    </>
+  );
+};
+
+render() {
+  return (
+    <>
+      {this.renderDatabaseUrl()}
+      {this.renderDatabaseCredentials()}
+    </>
+  );
+}
 }
 
 export default OrgIntegrationSection;

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -84,9 +84,7 @@ type State = {
 };
 
 class OrgIntegrationSection extends Component<Props, State> {
-
-  constructor(props :Props) {
-
+  constructor(props: Props) {
     super(props);
 
     this.state = {
@@ -95,150 +93,150 @@ class OrgIntegrationSection extends Component<Props, State> {
     };
   }
 
-  handleOnChangeForm = ({ formData } :{ formData :FormData }) => {
-
+  handleOnChangeForm = ({ formData }: { formData: FormData }) => {
     const { formData: stateFormData } = this.state;
 
     let newFormData = fromJS(formData);
     if (isNonEmptyString(formData.fields.targetDBMS)) {
-      if (stateFormData.getIn(['fields', 'targetDBMS']) !== newFormData.getIn(['fields', 'targetDBMS'])) {
-        const dbms :Object = DBMSTypes[formData.fields.targetDBMS];
-        newFormData = newFormData.setIn(['fields', 'targetPort'], dbms.port);
+      if (
+        stateFormData.getIn(["fields", "targetDBMS"]) !==
+        newFormData.getIn(["fields", "targetDBMS"])
+      ) {
+        const dbms: Object = DBMSTypes[formData.fields.targetDBMS];
+        newFormData = newFormData.setIn(["fields", "targetPort"], dbms.port);
       }
     }
 
     this.setState({ formData: newFormData });
-  }
+  };
 
   handleOnClickCopyCredential = () => {
-
     const { isOwner, org } = this.props;
 
     if (isOwner) {
       // TODO: consider using https://github.com/zenorocha/clipboard.js
       if (navigator.clipboard) {
-        navigator.clipboard.writeText(org.getIn(['integration', 'credential'], ''));
+        navigator.clipboard.writeText(
+          org.getIn(["integration", "credential"], "")
+        );
       }
     }
-  }
+  };
 
   handleOnClickGenerate = () => {
-
     const { org } = this.props;
     const { formData } = this.state;
 
     generateIntegrationConfigFile({
-      orgId: org.get('id'),
-      orgName: org.get('title'),
-      orgPassword: org.getIn(['integration', 'credential']),
-      orgUsername: org.getIn(['integration', 'user']),
-      targetDatabase: formData.getIn(['fields', 'targetDatabase']),
-      targetPort: formData.getIn(['fields', 'targetPort']),
-      targetServer: formData.getIn(['fields', 'targetServer']),
-      targetDBMS: formData.getIn(['fields', 'targetDBMS']),
+      orgId: org.get("id"),
+      orgName: org.get("title"),
+      orgPassword: org.getIn(["integration", "credential"]),
+      orgUsername: org.getIn(["integration", "user"]),
+      targetDatabase: formData.getIn(["fields", "targetDatabase"]),
+      targetPort: formData.getIn(["fields", "targetPort"]),
+      targetServer: formData.getIn(["fields", "targetServer"]),
+      targetDBMS: formData.getIn(["fields", "targetDBMS"]),
     });
-  }
+  };
 
   closeModal = () => {
-
     this.setState({
       formData: INITIAL_FORM_DATA,
       isVisibleGenerateConfigModal: false,
     });
-  }
+  };
 
   openModal = () => {
-
     this.setState({
       isVisibleGenerateConfigModal: true,
     });
-  }
+  };
 
   renderGenerateConfigModal = () => {
-
     const { formData, isVisibleGenerateConfigModal } = this.state;
 
     return (
       <Modal
-          isVisible={isVisibleGenerateConfigModal}
-          onClickPrimary={this.handleOnClickGenerate}
-          onClose={this.closeModal}
-          textPrimary="Generate"
-          textTitle="Generate Integration Configuration File"
-          viewportScrolling>
+        isVisible={isVisibleGenerateConfigModal}
+        onClickPrimary={this.handleOnClickGenerate}
+        onClose={this.closeModal}
+        textPrimary="Generate"
+        textTitle="Generate Integration Configuration File"
+        viewportScrolling
+      >
         <Form
-            formData={formData.toJS()}
-            hideSubmit
-            noPadding
-            onChange={this.handleOnChangeForm}
-            schema={dataSchema}
-            uiSchema={uiSchema} />
+          formData={formData.toJS()}
+          hideSubmit
+          noPadding
+          onChange={this.handleOnChangeForm}
+          schema={dataSchema}
+          uiSchema={uiSchema}
+        />
       </Modal>
     );
-  }
-renderDatabaseUrl = () => {
-  const { org } = this.props;
-  const orgIdClean = org.get('id').replace(/-/g, '');
+  };
+  renderDatabaseUrl = () => {
+    const { org } = this.props;
+    const orgIdClean = org.get("id").replace(/-/g, "");
 
-  return (
-    <SectionGrid>
-      <h2>Database Details</h2>
-      <h5>JDBC URL</h5>
-      <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
-    </SectionGrid>
-  );
-};
-
-renderDatabaseCredentials = () => {
-  const { isOwner, org } = this.props;
-
-  if (!isOwner) {
-    return null;
-  }
-
-  const integration:Map = org.get('integration', Map());
-  if (integration.isEmpty()) {
-    return null;
-  }
-
-  return (
-    <>
+    return (
       <SectionGrid>
-        <h5>USER</h5>
-        <pre>{org.getIn(["integration", "user"], "")}</pre>
-        <h5>CREDENTIAL</h5>
+        <h2>Database Details</h2>
+        <h5>JDBC URL</h5>
+        <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
       </SectionGrid>
-      <SectionGrid columns={2}>
-        <div style={{ marginTop: "4px" }}>
-          <ActionControlWithButton>
-            <Input
-              disabled
-              type="password"
-              value="********************************"
-            />
-            <CopyButton onClick={this.handleOnClickCopyCredential} />
-          </ActionControlWithButton>
-        </div>
-      </SectionGrid>
-      <SectionGrid columns={2}>
-        <div>
-          <Button mode="primary" onClick={this.openModal}>
-            Generate Integration Configuration File
-          </Button>
-        </div>
-      </SectionGrid>
-      {this.renderGenerateConfigModal()}
-    </>
-  );
+    );
+  };
 
-};
+  renderDatabaseCredentials = () => {
+    const { isOwner, org } = this.props;
 
-render() {
-  return (
-    <>
-    {this.renderDatabaseUrl()}
-    {this.renderDatabaseCredentials()}
-    </>
+    if (!isOwner) {
+      return null;
+    }
+
+    const integration: Map = org.get("integration", Map());
+    if (integration.isEmpty()) {
+      return null;
+    }
+
+    return (
+      <>
+        <SectionGrid>
+          <h5>USER</h5>
+          <pre>{org.getIn(['integration', 'user'], '')}</pre>
+          <h5>CREDENTIAL</h5>
+        </SectionGrid>
+        <SectionGrid columns={2}>
+          <div style={{ marginTop: '4px' }}>
+            <ActionControlWithButton>
+              <Input
+                disabled
+                type="password"
+                value="********************************"
+              />
+              <CopyButton onClick={this.handleOnClickCopyCredential} />
+            </ActionControlWithButton>
+          </div>
+        </SectionGrid>
+        <SectionGrid columns={2}>
+          <div>
+            <Button mode="primary" onClick={this.openModal}>
+              Generate Integration Configuration File
+            </Button>
+          </div>
+        </SectionGrid>
+        {this.renderGenerateConfigModal()}
+      </>
+    );
+  };
+
+  render() {
+    return (
+      <>
+        {this.renderDatabaseUrl()}
+        {this.renderDatabaseCredentials()}
+      </>
     );
   }
 }

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -176,37 +176,66 @@ class OrgIntegrationSection extends Component<Props, State> {
       </Modal>
     );
   }
-
-  render() {
-
+    
+  renderDatabaseUrl = () => {
     const { org } = this.props;
     const orgIdClean = org.get('id').replace(/-/g, '');
+    
+    return (
+      <SectionGrid>
+        <h2>Database Details</h2>
+        <h5>JDBC URL</h5>
+        <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
+      </SectionGrid>      
+    )
+    
+  }
+  
+  renderDatabaseCredentials = () => {
+    const { isOwner, org } = this.props;
+
+    if (!isOwner) {
+      return null;
+    }
+
+    const integration :Map = org.get('integration', Map());
+    if (integration.isEmpty()) {
+      return null;
+    }
 
     return (
       <>
-        <SectionGrid>
-          <h2>Integration Account Details</h2>
-          <h5>JDBC URL</h5>
-          <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
-          <h5>USER</h5>
-          <pre>{org.getIn(['integration', 'user'], '')}</pre>
-          <h5>CREDENTIAL</h5>
-        </SectionGrid>
-        <SectionGrid columns={2}>
-          <div style={{ marginTop: '4px' }}>
-            <ActionControlWithButton>
-              <Input disabled type="password" value="********************************" />
-              <CopyButton onClick={this.handleOnClickCopyCredential} />
-            </ActionControlWithButton>
-          </div>
-        </SectionGrid>
-        <SectionGrid columns={2}>
-          <div>
-            <Button mode="primary" onClick={this.openModal}>Generate Integration Configuration File</Button>
-          </div>
-        </SectionGrid>
-        {this.renderGenerateConfigModal()}
+      <SectionGrid>
+        <h5>USER</h5>
+        <pre>{org.getIn(['integration', 'user'], '')}</pre>
+        <h5>CREDENTIAL</h5>        
+      </SectionGrid>
+      <SectionGrid columns={2}>
+        <div style={{ marginTop: '4px' }}>
+          <ActionControlWithButton>
+            <Input disabled type="password" value="********************************" />
+            <CopyButton onClick={this.handleOnClickCopyCredential} />
+          </ActionControlWithButton>
+        </div>
+      </SectionGrid>
+      <SectionGrid columns={2}>
+        <div>
+          <Button mode="primary" onClick={this.openModal}>Generate Integration Configuration File</Button>
+        </div>
+      </SectionGrid>
+      {this.renderGenerateConfigModal()}      
       </>
+    )
+  }
+
+  render() {
+
+
+    return (
+      <>
+        {this.renderDatabaseUrl()}
+        {this.renderDatabaseCredentials()}
+    </>
     );
   }
 }

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -196,8 +196,7 @@ renderDatabaseCredentials = () => {
     return null;
   }
 
-  const integration: Map = org.get('integration', Map());
-  
+  const integration: Map = org.get('integration', Map());  
   if (integration.isEmpty()) {
     return null;
   }
@@ -230,16 +229,16 @@ renderDatabaseCredentials = () => {
       </SectionGrid>
       {this.renderGenerateConfigModal()}
   </>
-  );
+    );
 };
 
 render() {
   return (
     <>
-      {this.renderDatabaseUrl()}
-      {this.renderDatabaseCredentials()}
-  </>
-  );
+    {this.renderDatabaseUrl()}
+    {this.renderDatabaseCredentials()}
+    </>
+    );
   }
 }
 

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -176,57 +176,61 @@ class OrgIntegrationSection extends Component<Props, State> {
       </Modal>
     );
   }
-    
-  renderDatabaseUrl = () => {
-    const { org } = this.props;
-    const orgIdClean = org.get('id').replace(/-/g, '');
-    
-    return (
-      <SectionGrid>
-        <h2>Database Details</h2>
-        <h5>JDBC URL</h5>
-        <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
-      </SectionGrid>      
-    )
-    
+renderDatabaseUrl = () => {
+  const { org } = this.props;
+  const orgIdClean = org.get("id").replace(/-/g, "");
+
+  return (
+    <SectionGrid>
+      <h2>Database Details</h2>
+      <h5>JDBC URL</h5>
+      <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
+    </SectionGrid>
+  );
+};
+
+renderDatabaseCredentials = () => {
+  const { isOwner, org } = this.props;
+
+  if (!isOwner) {
+    return null;
   }
-  
-  renderDatabaseCredentials = () => {
-    const { isOwner, org } = this.props;
 
-    if (!isOwner) {
-      return null;
-    }
+  const integration: Map = org.get("integration", Map());
+  if (integration.isEmpty()) {
+    return null;
+  }
 
-    const integration :Map = org.get('integration', Map());
-    if (integration.isEmpty()) {
-      return null;
-    }
-
-    return (
-      <>
+  return (
+    <>
       <SectionGrid>
         <h5>USER</h5>
-        <pre>{org.getIn(['integration', 'user'], '')}</pre>
-        <h5>CREDENTIAL</h5>        
+        <pre>{org.getIn(["integration", "user"], "")}</pre>
+        <h5>CREDENTIAL</h5>
       </SectionGrid>
       <SectionGrid columns={2}>
-        <div style={{ marginTop: '4px' }}>
+        <div style={{ marginTop: "4px" }}>
           <ActionControlWithButton>
-            <Input disabled type="password" value="********************************" />
+            <Input
+              disabled
+              type="password"
+              value="********************************"
+            />
             <CopyButton onClick={this.handleOnClickCopyCredential} />
           </ActionControlWithButton>
         </div>
       </SectionGrid>
       <SectionGrid columns={2}>
         <div>
-          <Button mode="primary" onClick={this.openModal}>Generate Integration Configuration File</Button>
+          <Button mode="primary" onClick={this.openModal}>
+            Generate Integration Configuration File
+          </Button>
         </div>
       </SectionGrid>
-      {this.renderGenerateConfigModal()}      
-      </>
-    )
-  }
+      {this.renderGenerateConfigModal()}
+    </>
+  );
+};
 
   render() {
 

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -7,10 +7,7 @@ import React, { Component } from 'react';
 import { Map, fromJS } from 'immutable';
 import { Form } from 'lattice-fabricate';
 import {
-  Button,
-  CopyButton,
-  Input,
-  Modal,
+  Button, CopyButton, Input, Modal
 } from 'lattice-ui-kit';
 
 import DBMSTypes from '../../../utils/integration-config/DBMSTypes';
@@ -25,33 +22,33 @@ const dataSchema = {
       properties: {
         targetServer: {
           title: 'Target Server',
-          type: 'string',
+          type: 'string'
         },
         targetDatabase: {
           title: 'Target Database',
-          type: 'string',
+          type: 'string'
         },
         targetDBMS: {
           enum: Object.keys(DBMSTypes),
           title: 'Target DBMS',
-          type: 'string',
+          type: 'string'
         },
         targetPort: {
           title: 'Target Port',
-          type: 'number',
-        },
+          type: 'number'
+        }
       },
       title: '',
-      type: 'object',
-    },
+      type: 'object'
+    }
   },
   title: '',
-  type: 'object',
+  type: 'object'
 };
 
 const uiSchema = {
   fields: {
-    classNames: 'column-span-12',
+    classNames: 'column-span-12'
   }
 };
 
@@ -60,50 +57,47 @@ const INITIAL_FORM_DATA = fromJS({
     targetDBMS: '',
     targetDatabase: '',
     targetPort: 5432,
-    targetServer: '',
+    targetServer: ''
   }
 });
 
 type FormData = {
-  fields :{
-    targetDBMS :?string;
-    targetDatabase :?string;
-    targetPort :?number;
-    targetServer :?string;
-  };
+  fields:{
+    targetDBMS:?string,
+    targetDatabase:?string,
+    targetPort:?number,
+    targetServer:?string
+  }
 };
 
 type Props = {
-  isOwner :boolean;
-  org :Map;
+  isOwner:boolean,
+  org:Map
 };
 
 type State = {
-  formData :Map;
-  isVisibleGenerateConfigModal :boolean;
+  formData:Map,
+  isVisibleGenerateConfigModal:boolean
 };
 
 class OrgIntegrationSection extends Component<Props, State> {
-  constructor(props: Props) {
+  constructor(props:Props) {
     super(props);
 
     this.state = {
       formData: INITIAL_FORM_DATA,
-      isVisibleGenerateConfigModal: false,
+      isVisibleGenerateConfigModal: false
     };
   }
 
-  handleOnChangeForm = ({ formData }: { formData: FormData }) => {
+  handleOnChangeForm = ({ formData }:{ formData:FormData }) => {
     const { formData: stateFormData } = this.state;
 
     let newFormData = fromJS(formData);
     if (isNonEmptyString(formData.fields.targetDBMS)) {
-      if (
-        stateFormData.getIn(["fields", "targetDBMS"]) !==
-        newFormData.getIn(["fields", "targetDBMS"])
-      ) {
-        const dbms: Object = DBMSTypes[formData.fields.targetDBMS];
-        newFormData = newFormData.setIn(["fields", "targetPort"], dbms.port);
+      if (stateFormData.getIn(['fields', 'targetDBMS']) !== newFormData.getIn(['fields', 'targetDBMS'])) {
+        const dbms:Object = DBMSTypes[formData.fields.targetDBMS];
+        newFormData = newFormData.setIn(['fields', 'targetPort'], dbms.port);
       }
     }
 
@@ -116,9 +110,7 @@ class OrgIntegrationSection extends Component<Props, State> {
     if (isOwner) {
       // TODO: consider using https://github.com/zenorocha/clipboard.js
       if (navigator.clipboard) {
-        navigator.clipboard.writeText(
-          org.getIn(["integration", "credential"], "")
-        );
+        navigator.clipboard.writeText(org.getIn(['integration', 'credential'], ''));
       }
     }
   };
@@ -128,27 +120,27 @@ class OrgIntegrationSection extends Component<Props, State> {
     const { formData } = this.state;
 
     generateIntegrationConfigFile({
-      orgId: org.get("id"),
-      orgName: org.get("title"),
-      orgPassword: org.getIn(["integration", "credential"]),
-      orgUsername: org.getIn(["integration", "user"]),
-      targetDatabase: formData.getIn(["fields", "targetDatabase"]),
-      targetPort: formData.getIn(["fields", "targetPort"]),
-      targetServer: formData.getIn(["fields", "targetServer"]),
-      targetDBMS: formData.getIn(["fields", "targetDBMS"]),
+      orgId: org.get('id'),
+      orgName: org.get('title'),
+      orgPassword: org.getIn(['integration', 'credential']),
+      orgUsername: org.getIn(['integration', 'user']),
+      targetDatabase: formData.getIn(['fields', 'targetDatabase']),
+      targetPort: formData.getIn(['fields', 'targetPort']),
+      targetServer: formData.getIn(['fields', 'targetServer']),
+      targetDBMS: formData.getIn(['fields', 'targetDBMS'])
     });
   };
 
   closeModal = () => {
     this.setState({
       formData: INITIAL_FORM_DATA,
-      isVisibleGenerateConfigModal: false,
+      isVisibleGenerateConfigModal: false
     });
   };
 
   openModal = () => {
     this.setState({
-      isVisibleGenerateConfigModal: true,
+      isVisibleGenerateConfigModal: true
     });
   };
 
@@ -157,27 +149,25 @@ class OrgIntegrationSection extends Component<Props, State> {
 
     return (
       <Modal
-        isVisible={isVisibleGenerateConfigModal}
-        onClickPrimary={this.handleOnClickGenerate}
-        onClose={this.closeModal}
-        textPrimary="Generate"
-        textTitle="Generate Integration Configuration File"
-        viewportScrolling
-      >
+          isVisible={isVisibleGenerateConfigModal}
+          onClickPrimary={this.handleOnClickGenerate}
+          onClose={this.closeModal}
+          textPrimary="Generate"
+          textTitle="Generate Integration Configuration File"
+          viewportScrolling>
         <Form
-          formData={formData.toJS()}
-          hideSubmit
-          noPadding
-          onChange={this.handleOnChangeForm}
-          schema={dataSchema}
-          uiSchema={uiSchema}
-        />
+            formData={formData.toJS()}
+            hideSubmit
+            noPadding
+            onChange={this.handleOnChangeForm}
+            schema={dataSchema}
+            uiSchema={uiSchema} />
       </Modal>
     );
   };
   renderDatabaseUrl = () => {
     const { org } = this.props;
-    const orgIdClean = org.get("id").replace(/-/g, "");
+    const orgIdClean = org.get('id').replace(/-/g, '');
 
     return (
       <SectionGrid>
@@ -195,7 +185,8 @@ class OrgIntegrationSection extends Component<Props, State> {
       return null;
     }
 
-    const integration: Map = org.get("integration", Map());
+    const integration:Map = org.get('integration', Map());
+
     if (integration.isEmpty()) {
       return null;
     }
@@ -210,11 +201,7 @@ class OrgIntegrationSection extends Component<Props, State> {
         <SectionGrid columns={2}>
           <div style={{ marginTop: '4px' }}>
             <ActionControlWithButton>
-              <Input
-                disabled
-                type="password"
-                value="********************************"
-              />
+              <Input disabled type="password" value="********************************" />
               <CopyButton onClick={this.handleOnClickCopyCredential} />
             </ActionControlWithButton>
           </div>

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -163,8 +163,8 @@ class OrgIntegrationSection extends Component<Props, State> {
           isVisible={isVisibleGenerateConfigModal}
           onClickPrimary={this.handleOnClickGenerate}
           onClose={this.closeModal}
-          textPrimary="Generate"
-          textTitle="Generate Integration Configuration File"
+          textPrimary='Generate'
+          textTitle='Generate Integration Configuration File'
           viewportScrolling>
         <Form
             formData={formData.toJS()}
@@ -178,7 +178,7 @@ class OrgIntegrationSection extends Component<Props, State> {
   }
 renderDatabaseUrl = () => {
   const { org } = this.props;
-  const orgIdClean = org.get("id").replace(/-/g, "");
+  const orgIdClean = org.get('id').replace(/-/g, '');
 
   return (
     <SectionGrid>
@@ -196,7 +196,7 @@ renderDatabaseCredentials = () => {
     return null;
   }
 
-  const integration: Map = org.get("integration", Map());
+  const integration: Map = org.get('integration', Map());
   if (integration.isEmpty()) {
     return null;
   }
@@ -205,16 +205,16 @@ renderDatabaseCredentials = () => {
     <>
       <SectionGrid>
         <h5>USER</h5>
-        <pre>{org.getIn(["integration", "user"], "")}</pre>
+        <pre>{org.getIn(['integration', 'user'], '')}</pre>
         <h5>CREDENTIAL</h5>
       </SectionGrid>
       <SectionGrid columns={2}>
-        <div style={{ marginTop: "4px" }}>
+        <div style={{ marginTop: '4px' }}>
           <ActionControlWithButton>
             <Input
-              disabled
-              type="password"
-              value="********************************"
+                disabled
+                type='password'
+                value='********************************'
             />
             <CopyButton onClick={this.handleOnClickCopyCredential} />
           </ActionControlWithButton>
@@ -222,19 +222,17 @@ renderDatabaseCredentials = () => {
       </SectionGrid>
       <SectionGrid columns={2}>
         <div>
-          <Button mode="primary" onClick={this.openModal}>
+          <Button mode='primary' onClick={this.openModal}>
             Generate Integration Configuration File
           </Button>
         </div>
       </SectionGrid>
       {this.renderGenerateConfigModal()}
     </>
-  );
-};
+    );
+  };
 
   render() {
-
-
     return (
       <>
         {this.renderDatabaseUrl()}

--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -196,7 +196,7 @@ renderDatabaseCredentials = () => {
     return null;
   }
 
-  const integration: Map = org.get('integration', Map());  
+  const integration:Map = org.get('integration', Map());
   if (integration.isEmpty()) {
     return null;
   }
@@ -205,16 +205,16 @@ renderDatabaseCredentials = () => {
     <>
       <SectionGrid>
         <h5>USER</h5>
-        <pre>{org.getIn(['integration', 'user'], '')}</pre>
+        <pre>{org.getIn(["integration", "user"], "")}</pre>
         <h5>CREDENTIAL</h5>
       </SectionGrid>
       <SectionGrid columns={2}>
-        <div style={{ marginTop: '4px' }}>
+        <div style={{ marginTop: "4px" }}>
           <ActionControlWithButton>
             <Input
-                disabled
-                type="password"
-                value="********************************"
+              disabled
+              type="password"
+              value="********************************"
             />
             <CopyButton onClick={this.handleOnClickCopyCredential} />
           </ActionControlWithButton>
@@ -228,8 +228,9 @@ renderDatabaseCredentials = () => {
         </div>
       </SectionGrid>
       {this.renderGenerateConfigModal()}
-  </>
-    );
+    </>
+  );
+
 };
 
 render() {


### PR DESCRIPTION
- changed title from Integration Details to Database Details, since the atlas-db is now used for more than integrations.
- remove owner-check in OrgDetailsContainer, and moved it to OrgIntegrationSection.
- split up OrgIntegrationSection into:
    - renderDatabaseUrl()
    - renderDatabaseCredentials()

Non-owners should have access to the URL but not the credentials, this fixes https://jira.openlattice.com/browse/APPS-1937.  

![image](https://user-images.githubusercontent.com/7630327/79702946-489c6580-825d-11ea-9726-c660ad15e280.png)
