### PR TITLE
put the ID in the integration section

### DIFF
--- a/src/containers/orgs/components/OrgIntegrationSection.js
+++ b/src/containers/orgs/components/OrgIntegrationSection.js
@@ -179,11 +179,14 @@ class OrgIntegrationSection extends Component<Props, State> {
 
   renderDatabaseUrl = () => {
     const { org } = this.props;
-    const orgIdClean = org.get('id').replace(/-/g, '');
+    const orgId = org.get('id');
+    const orgIdClean = orgId.replace(/-/g, '');
 
     return (
       <SectionGrid>
         <h2>Database Details</h2>
+        <h5>Organization ID</h5>
+        <pre>{orgId}</pre>
         <h5>JDBC URL</h5>
         <pre>{`jdbc:postgresql://atlas.openlattice.com:30001/org_${orgIdClean}`}</pre>
       </SectionGrid>


### PR DESCRIPTION
Adding organization ID to the integration section.
Note that the USER-id is only visible to org-owners.  As such this is the only place they can easily copy/paste (the URL too, but that's not clear enough).

![image](https://user-images.githubusercontent.com/7630327/81214422-abe00480-8f8c-11ea-9103-c75279bf4a6f.png)
