### PR TITLE
APPS-2753: Show Lock Icon When Not Authorized To View Permissions

### DIFF
--- a/src/containers/org/DataSetMetaContainer.js
+++ b/src/containers/org/DataSetMetaContainer.js
@@ -78,11 +78,13 @@ const DataSetMetaContainer = ({
   dataSetId,
   entitySet,
   isOwner,
+  organizationId
 } :{|
   atlasDataSet :?Map;
   dataSetId :UUID;
   entitySet :?EntitySet;
   isOwner :boolean;
+  organizationId :UUID;
 |}) => {
 
   const dispatch = useDispatch();
@@ -116,9 +118,10 @@ const DataSetMetaContainer = ({
     dispatch(getOwnerStatus(dataSetId));
     dispatch(getCurrentDataSetAuthorizations({
       aclKey: [dataSetId],
+      organizationId,
       permissions: [PermissionTypes.MATERIALIZE]
     }));
-  }, [dispatch, dataSetId]);
+  }, [dispatch, dataSetId, organizationId]);
 
   useEffect(() => {
     if (parsedColumnInfo) {

--- a/src/containers/org/OrgDataSetContainer.js
+++ b/src/containers/org/OrgDataSetContainer.js
@@ -87,7 +87,12 @@ const OrgDataSetContainer = ({
     );
 
     const renderDataSetMetaContainer = () => (
-      <DataSetMetaContainer atlasDataSet={atlasDataSet} dataSetId={dataSetId} entitySet={entitySet} isOwner={isOwner} />
+      <DataSetMetaContainer
+          atlasDataSet={atlasDataSet}
+          dataSetId={dataSetId}
+          entitySet={entitySet}
+          isOwner={isOwner}
+          organizationId={organizationId} />
     );
 
     return (

--- a/src/containers/permissions/DataSetPermissionsCard.js
+++ b/src/containers/permissions/DataSetPermissionsCard.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import type { ComponentType } from 'react';
 
 import _capitalize from 'lodash/capitalize';
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 import { List, Map } from 'immutable';
 import { Types } from 'lattice';
 import { Colors, Typography } from 'lattice-ui-kit';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import type {
   Ace,
   EntitySet,
@@ -27,6 +27,7 @@ import { DataSetTitle, SpaceBetweenGrid, StackGrid } from '../../components';
 import { selectDataSetProperties, selectPermissionsByPrincipal } from '../../core/redux/selectors';
 import { getDataSetField, getDataSetKeys } from '../../utils';
 import type { DataSetPermissionTypeSelection } from '../../types';
+import { getCurrentDataSetAuthorizations } from '../../core/permissions/actions';
 
 const { NEUTRAL, PURPLE } = Colors;
 const { PermissionTypes } = Types;
@@ -74,7 +75,17 @@ const DataSetPermissionsCard = ({
   selection :?DataSetPermissionTypeSelection;
 |}) => {
 
+  const dispatch = useDispatch();
   const dataSetId :UUID = getDataSetField(dataSet, 'id');
+  useEffect(() => {
+    if (isOpen && dataSetId) {
+      dispatch(getCurrentDataSetAuthorizations({
+        aclKey: [dataSetId],
+        permissions: [PermissionTypes.OWNER],
+        withProperties: true
+      }));
+    }
+  }, [dispatch, isOpen, dataSetId]);
 
   const properties :Map<UUID, PropertyType | Map> = useSelector(selectDataSetProperties(dataSetId));
   const keys :List<List<UUID>> = useMemo(() => (

--- a/src/containers/permissions/DataSetPermissionsCard.js
+++ b/src/containers/permissions/DataSetPermissionsCard.js
@@ -64,6 +64,7 @@ const DataSetPermissionsCard = ({
   isOpen,
   onClick,
   onSelect,
+  organizationId,
   principal,
   selection,
 } :{|
@@ -72,6 +73,7 @@ const DataSetPermissionsCard = ({
   onClick :(dataSetId :UUID) => void;
   onSelect :(selection :DataSetPermissionTypeSelection) => void;
   principal :Principal;
+  organizationId :UUID;
   selection :?DataSetPermissionTypeSelection;
 |}) => {
 
@@ -81,11 +83,12 @@ const DataSetPermissionsCard = ({
     if (isOpen && dataSetId) {
       dispatch(getCurrentDataSetAuthorizations({
         aclKey: [dataSetId],
+        organizationId,
         permissions: [PermissionTypes.OWNER],
         withProperties: true
       }));
     }
-  }, [dispatch, isOpen, dataSetId]);
+  }, [dispatch, isOpen, dataSetId, organizationId]);
 
   const properties :Map<UUID, PropertyType | Map> = useSelector(selectDataSetProperties(dataSetId));
   const keys :List<List<UUID>> = useMemo(() => (

--- a/src/containers/permissions/DataSetPermissionsContainer.js
+++ b/src/containers/permissions/DataSetPermissionsContainer.js
@@ -192,6 +192,7 @@ const DataSetPermissionsContainer = ({
                   key={dataSetId}
                   onClick={toggleOpenDataSetCard}
                   onSelect={onSelect}
+                  organizationId={organizationId}
                   principal={principal}
                   selection={selection} />
             );

--- a/src/containers/permissions/DataSetPermissionsContainer.js
+++ b/src/containers/permissions/DataSetPermissionsContainer.js
@@ -13,7 +13,6 @@ import { List, Map, Set } from 'immutable';
 import { PaginationToolbar, Typography } from 'lattice-ui-kit';
 import { ReduxUtils, useRequestState } from 'lattice-utils';
 import { useDispatch, useSelector } from 'react-redux';
-import { RequestStates } from 'redux-reqseq';
 import type {
   Ace,
   EntitySet,
@@ -47,7 +46,7 @@ import type { State as PaginationState } from '../../utils/stateReducers/paginat
 
 const MAX_PER_PAGE = 10;
 
-const { reduceRequestStates } = ReduxUtils;
+const { isPending, isSuccess, reduceRequestStates } = ReduxUtils;
 
 const DataSetPermissionsContainer = ({
   filterByPermissionTypes,
@@ -163,22 +162,27 @@ const DataSetPermissionsContainer = ({
     }
   };
 
-  const reducedRS :?RequestState = reduceRequestStates([getPermissionsRS, initializePermissionsRS]);
+  const reducedRS :?RequestState = reduceRequestStates([
+    getPermissionsRS,
+    initializePermissionsRS
+  ]);
+  const requestIsPending = isPending(reducedRS);
+  const requestIsSuccess = isSuccess(reducedRS);
 
   return (
     <StackGrid gap={8}>
       {
-        reducedRS === RequestStates.PENDING && (
+        requestIsPending && (
           <Spinner />
         )
       }
       {
-        reducedRS === RequestStates.SUCCESS && filteredPermissionsCount === 0 && (
+        requestIsSuccess && filteredPermissionsCount === 0 && (
           <Typography align="center">No datasets.</Typography>
         )
       }
       {
-        reducedRS === RequestStates.SUCCESS && filteredPermissionsCount !== 0 && (
+        requestIsSuccess && filteredPermissionsCount !== 0 && (
           pageDataSets.valueSeq().map((dataSet :EntitySet | Map) => {
             const dataSetId :UUID = getDataSetField(dataSet, 'id');
             return (

--- a/src/containers/permissions/ObjectPermissionsCard.js
+++ b/src/containers/permissions/ObjectPermissionsCard.js
@@ -36,11 +36,12 @@ import type {
 } from 'lattice';
 import type { RequestState } from 'redux-reqseq';
 
+import { PropertyPermissionsCheckbox } from './components';
 import { ORDERED_PERMISSIONS } from './constants';
 
 import { SpaceBetweenGrid, Spinner, StackGrid } from '../../components';
 import { UPDATE_PERMISSIONS, updatePermissions } from '../../core/permissions/actions';
-import { PERMISSIONS } from '../../core/redux/constants';
+import { CURRENT, PERMISSIONS } from '../../core/redux/constants';
 import { selectUser } from '../../core/redux/selectors';
 import { getPrincipalTitle } from '../../utils';
 
@@ -91,6 +92,7 @@ const ObjectPermissionsCard = ({
   const updatePermissionsRS :?RequestState = useRequestState([PERMISSIONS, UPDATE_PERMISSIONS]);
 
   const user :Map = useSelector(selectUser(principal.id));
+  const currentDataSetPermissions :Map = useSelector((state) => state.getIn([PERMISSIONS, CURRENT]));
   const thisUserInfo = AuthUtils.getUserInfo() || { id: '' };
   const thisUserId = thisUserInfo.id;
   const title :string = getPrincipalTitle(principal, user, thisUserId);
@@ -211,6 +213,8 @@ const ObjectPermissionsCard = ({
                                 const propertyTypeFQN :?string = property?.type?.toString() || '';
                                 const key :List<UUID> = List([objectKey.get(0), propertyId]);
                                 const ace :?Ace = permissions.get(key);
+                                const currentUserIsOwner :boolean = currentDataSetPermissions
+                                  .getIn([key, PermissionTypes.OWNER], false);
                                 return (
                                   <SpaceBetweenGrid key={propertyId}>
                                     <Typography data-property-id={propertyId} title={propertyTypeFQN}>
@@ -224,11 +228,12 @@ const ObjectPermissionsCard = ({
                                           </SpinnerWrapper>
                                         )
                                         : (
-                                          <Checkbox
-                                              data-permission-type={permissionType}
-                                              data-property-id={propertyId}
-                                              checked={ace?.permissions.includes(permissionType)}
-                                              onChange={handleOnChangePermission} />
+                                          <PropertyPermissionsCheckbox
+                                              ace={ace}
+                                              isLocked={!currentUserIsOwner}
+                                              onChange={handleOnChangePermission}
+                                              permissionType={permissionType}
+                                              propertyId={propertyId} />
                                         )
                                     }
                                   </SpaceBetweenGrid>

--- a/src/containers/permissions/ObjectPermissionsContainer.js
+++ b/src/containers/permissions/ObjectPermissionsContainer.js
@@ -125,11 +125,12 @@ const ObjectPermissionsContainer = ({
     if (dataSetId) {
       dispatch(getCurrentDataSetAuthorizations({
         aclKey: [dataSetId],
+        organizationId,
         permissions: [PermissionTypes.OWNER],
         withProperties: true
       }));
     }
-  }, [dispatch, dataSetId]);
+  }, [dispatch, dataSetId, organizationId]);
 
   const handleOnPageChange = (state :PaginationState) => {
     paginationDispatch({

--- a/src/containers/permissions/ObjectPermissionsContainer.js
+++ b/src/containers/permissions/ObjectPermissionsContainer.js
@@ -9,11 +9,11 @@ import React, {
 } from 'react';
 
 import { List, Map } from 'immutable';
+import { Types } from 'lattice';
 import { AuthUtils } from 'lattice-auth';
 import { Modal, PaginationToolbar, Typography } from 'lattice-ui-kit';
-import { useRequestState } from 'lattice-utils';
+import { ReduxUtils, useRequestState } from 'lattice-utils';
 import { useDispatch, useSelector } from 'react-redux';
-import { RequestStates } from 'redux-reqseq';
 import type {
   Ace,
   PermissionType,
@@ -27,7 +27,11 @@ import ObjectPermissionsCard from './ObjectPermissionsCard';
 import { AssignPermissionsToObjectModalBody } from './assign-permissions-to-object';
 
 import { Spinner, StackGrid } from '../../components';
-import { INITIALIZE_OBJECT_PERMISSIONS, initializeObjectPermissions } from '../../core/permissions/actions';
+import {
+  INITIALIZE_OBJECT_PERMISSIONS,
+  getCurrentDataSetAuthorizations,
+  initializeObjectPermissions
+} from '../../core/permissions/actions';
 import { PERMISSIONS } from '../../core/redux/constants';
 import {
   selectDataSetProperties,
@@ -37,6 +41,10 @@ import {
 import { getDataSetKeys, getPrincipalTitle } from '../../utils';
 import { INITIAL_PAGINATION_STATE, PAGE, paginationReducer } from '../../utils/stateReducers/pagination';
 import type { State as PaginationState } from '../../utils/stateReducers/pagination';
+
+const { isPending, isSuccess } = ReduxUtils;
+
+const { PermissionTypes } = Types;
 
 const MAX_PER_PAGE = 10;
 
@@ -64,6 +72,8 @@ const ObjectPermissionsContainer = ({
   const { page, start } = paginationState;
 
   const initializeRS :?RequestState = useRequestState([PERMISSIONS, INITIALIZE_OBJECT_PERMISSIONS]);
+  const requestIsPending :boolean = isPending(initializeRS);
+  const requestIsSuccess :boolean = isSuccess(initializeRS);
 
   const users :Map<string, Map> = useSelector(selectUsers());
   const usersHash :number = users.hashCode();
@@ -111,6 +121,16 @@ const ObjectPermissionsContainer = ({
     dispatch(initializeObjectPermissions({ isDataSet: !!dataSetId, objectKey, organizationId }));
   }, [dataSetId, dispatch, objectKey, organizationId]);
 
+  useEffect(() => {
+    if (dataSetId) {
+      dispatch(getCurrentDataSetAuthorizations({
+        aclKey: [dataSetId],
+        permissions: [PermissionTypes.OWNER],
+        withProperties: true
+      }));
+    }
+  }, [dispatch, dataSetId]);
+
   const handleOnPageChange = (state :PaginationState) => {
     paginationDispatch({
       page: state.page,
@@ -122,17 +142,17 @@ const ObjectPermissionsContainer = ({
   return (
     <StackGrid gap={0}>
       {
-        initializeRS === RequestStates.PENDING && (
+        requestIsPending && (
           <Spinner />
         )
       }
       {
-        initializeRS === RequestStates.SUCCESS && filteredPermissionsCount === 0 && (
+        requestIsSuccess && filteredPermissionsCount === 0 && (
           <Typography align="center">No permissions assigned.</Typography>
         )
       }
       {
-        initializeRS === RequestStates.SUCCESS && filteredPermissionsCount !== 0 && (
+        requestIsSuccess && filteredPermissionsCount !== 0 && (
           pagePermissions.map((principalPermissions :Map<List<UUID>, Ace>, principal :Principal) => (
             <ObjectPermissionsCard
                 isDataSet={!!dataSetId}

--- a/src/containers/permissions/PermissionsPanel.js
+++ b/src/containers/permissions/PermissionsPanel.js
@@ -91,6 +91,7 @@ const PermissionsPanel = ({
 
   const dispatch = useDispatch();
   const [isPermissionAssignedToAll, setIsPermissionAssignedToAll] = useState(false);
+  const [isPermissionAssignedToAllDisabled, setIsPermissionAssignedToAllDisabled] = useState(false);
   const [isPermissionAssignedToDataSet, setIsPermissionAssignedToDataSet] = useState(false);
   const [isPermissionAssignedToOnlyNonPII, setIsPermissionAssignedToOnlyNonPII] = useState(false);
   const [localPermissions, setLocalPermissions] = useState(Map());
@@ -118,6 +119,19 @@ const PermissionsPanel = ({
   useEffect(() => {
     setLocalPermissions(principalPermissions);
   }, [principalPermissionsHash]);
+
+  useEffect(() => {
+    const ownerOnAllProperties = properties.every((property :PropertyType | Map) => {
+      const propertyId :UUID = property.id || get(property, 'id');
+      const key :List<UUID> = List([dataSetId, propertyId]);
+      const isOwner = currentDataSetPermissions
+        .getIn([key, PermissionTypes.OWNER], false);
+      return isOwner;
+    });
+    if (ownerOnAllProperties) {
+      setIsPermissionAssignedToAllDisabled(true);
+    }
+  }, [currentDataSetPermissions, dataSetId, setIsPermissionAssignedToAllDisabled, properties]);
 
   useEffect(() => {
 
@@ -307,6 +321,7 @@ const PermissionsPanel = ({
             <Typography>All properties</Typography>
             <IconButton
                 aria-label="permissions toggle for all properties"
+                disabled={!isPermissionAssignedToAllDisabled}
                 onClick={togglePermissionAssignmentAll}>
               <FontAwesomeIcon
                   color={isPermissionAssignedToAll ? PURPLE.P300 : NEUTRAL.N500}
@@ -322,6 +337,7 @@ const PermissionsPanel = ({
             <Typography>Only non-pii properties</Typography>
             <IconButton
                 aria-label="permissions toggle for only non-pii properties"
+                disabled={!isPermissionAssignedToAllDisabled}
                 onClick={togglePermissionAssignmentOnlyNonPII}>
               <FontAwesomeIcon
                   color={isPermissionAssignedToOnlyNonPII ? PURPLE.P300 : NEUTRAL.N500}

--- a/src/containers/permissions/components/PropertyPermissionsCheckbox.js
+++ b/src/containers/permissions/components/PropertyPermissionsCheckbox.js
@@ -6,6 +6,7 @@ import React from 'react';
 
 import { faLock } from '@fortawesome/pro-light-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+// $FlowFixMe
 import { Checkbox, Tooltip } from 'lattice-ui-kit';
 import type {
   Ace,

--- a/src/containers/permissions/components/PropertyPermissionsCheckbox.js
+++ b/src/containers/permissions/components/PropertyPermissionsCheckbox.js
@@ -1,0 +1,46 @@
+/*
+ * @flow
+ */
+
+import React from 'react';
+
+import { faLock } from '@fortawesome/pro-light-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Checkbox, Tooltip } from 'lattice-ui-kit';
+import type {
+  Ace,
+  PermissionType,
+  UUID,
+} from 'lattice';
+
+const PropertyPermissionsCheckbox = ({
+  ace,
+  isLocked,
+  onChange,
+  permissionType,
+  propertyId,
+} :{|
+  ace :?Ace;
+  isLocked :boolean;
+  onChange :(event :SyntheticEvent<HTMLInputElement>) => void;
+  permissionType :PermissionType;
+  propertyId :UUID;
+|}) => (
+  isLocked
+    ? (
+      <Tooltip arrow placement="left" title="Unauthorized to view permissions">
+        <div>
+          <FontAwesomeIcon fixedWidth icon={faLock} />
+        </div>
+      </Tooltip>
+    )
+    : (
+      <Checkbox
+          data-permission-type={permissionType}
+          data-property-id={propertyId}
+          checked={ace?.permissions.includes(permissionType)}
+          onChange={onChange} />
+    )
+);
+
+export default PropertyPermissionsCheckbox;

--- a/src/containers/permissions/components/index.js
+++ b/src/containers/permissions/components/index.js
@@ -1,0 +1,5 @@
+/*
+ * @flow
+ */
+
+export { default as PropertyPermissionsCheckbox } from './PropertyPermissionsCheckbox';

--- a/src/core/permissions/actions/index.js
+++ b/src/core/permissions/actions/index.js
@@ -16,6 +16,9 @@ const getCurrentDataSetAuthorizations :RequestSequence = newRequestSequence(GET_
 const GET_CURRENT_ROLE_AUTHORIZATIONS :'GET_CURRENT_ROLE_AUTHORIZATIONS' = 'GET_CURRENT_ROLE_AUTHORIZATIONS';
 const getCurrentRoleAuthorizations :RequestSequence = newRequestSequence(GET_CURRENT_ROLE_AUTHORIZATIONS);
 
+const GET_DATA_SET_KEYS :'GET_DATA_SET_KEYS' = 'GET_DATA_SET_KEYS';
+const getDataSetKeys :RequestSequence = newRequestSequence(GET_DATA_SET_KEYS);
+
 const GET_DATA_SET_PERMISSIONS :'GET_DATA_SET_PERMISSIONS' = 'GET_DATA_SET_PERMISSIONS';
 const getDataSetPermissions :RequestSequence = newRequestSequence(GET_DATA_SET_PERMISSIONS);
 
@@ -58,6 +61,7 @@ export {
   ASSIGN_PERMISSIONS_TO_DATA_SET,
   GET_CURRENT_DATA_SET_AUTHORIZATIONS,
   GET_CURRENT_ROLE_AUTHORIZATIONS,
+  GET_DATA_SET_KEYS,
   GET_DATA_SET_PERMISSIONS,
   GET_ORG_DATA_SET_OBJECT_PERMISSIONS,
   GET_ORG_OBJECT_PERMISSIONS,
@@ -73,6 +77,7 @@ export {
   assignPermissionsToDataSet,
   getCurrentDataSetAuthorizations,
   getCurrentRoleAuthorizations,
+  getDataSetKeys,
   getDataSetPermissions,
   getOrgDataSetObjectPermissions,
   getOrgObjectPermissions,

--- a/src/core/permissions/reducers/getDataSetKeysReducer.js
+++ b/src/core/permissions/reducers/getDataSetKeysReducer.js
@@ -1,0 +1,22 @@
+/*
+ * @flow
+ */
+
+import { Map } from 'immutable';
+import { RequestStates } from 'redux-reqseq';
+import type { SequenceAction } from 'redux-reqseq';
+
+import { REQUEST_STATE } from '../../redux/constants';
+import {
+  GET_DATA_SET_KEYS,
+  getDataSetKeys,
+} from '../actions';
+
+export default function reducer(state :Map, action :SequenceAction) {
+
+  return getDataSetKeys.reducer(state, action, {
+    REQUEST: () => state.setIn([GET_DATA_SET_KEYS, REQUEST_STATE], RequestStates.PENDING),
+    SUCCESS: () => state.setIn([GET_DATA_SET_KEYS, REQUEST_STATE], RequestStates.SUCCESS),
+    FAILURE: () => state.setIn([GET_DATA_SET_KEYS, REQUEST_STATE], RequestStates.FAILURE),
+  });
+}

--- a/src/core/permissions/reducers/index.js
+++ b/src/core/permissions/reducers/index.js
@@ -7,6 +7,7 @@ import { Map, fromJS } from 'immutable';
 import assignPermissionsToDataSetReducer from './assignPermissionsToDataSetReducer';
 import getCurrentDataSetAuthorizationsReducer from './getCurrentDataSetAuthorizationsReducer';
 import getCurrentRoleAuthorizationsReducer from './getCurrentRoleAuthorizationsReducer';
+import getDataSetKeysReducer from './getDataSetKeysReducer';
 import getDataSetPermissionsReducer from './getDataSetPermissionsReducer';
 import getOrgDataSetObjectPermissionsReducer from './getOrgDataSetObjectPermissionsReducer';
 import getOrgObjectPermissionsReducer from './getOrgObjectPermissionsReducer';
@@ -32,6 +33,7 @@ import {
   ASSIGN_PERMISSIONS_TO_DATA_SET,
   GET_CURRENT_DATA_SET_AUTHORIZATIONS,
   GET_CURRENT_ROLE_AUTHORIZATIONS,
+  GET_DATA_SET_KEYS,
   GET_DATA_SET_PERMISSIONS,
   GET_ORG_DATA_SET_OBJECT_PERMISSIONS,
   GET_ORG_OBJECT_PERMISSIONS,
@@ -47,6 +49,7 @@ import {
   assignPermissionsToDataSet,
   getCurrentDataSetAuthorizations,
   getCurrentRoleAuthorizations,
+  getDataSetKeys,
   getDataSetPermissions,
   getOrgDataSetObjectPermissions,
   getOrgObjectPermissions,
@@ -65,6 +68,7 @@ const INITIAL_STATE :Map = fromJS({
   [ASSIGN_PERMISSIONS_TO_DATA_SET]: RS_INITIAL_STATE,
   [GET_CURRENT_DATA_SET_AUTHORIZATIONS]: RS_INITIAL_STATE,
   [GET_CURRENT_ROLE_AUTHORIZATIONS]: RS_INITIAL_STATE,
+  [GET_DATA_SET_KEYS]: RS_INITIAL_STATE,
   [GET_DATA_SET_PERMISSIONS]: RS_INITIAL_STATE,
   [GET_ORG_DATA_SET_OBJECT_PERMISSIONS]: RS_INITIAL_STATE,
   [GET_ORG_OBJECT_PERMISSIONS]: RS_INITIAL_STATE,
@@ -105,6 +109,10 @@ export default function reducer(state :Map = INITIAL_STATE, action :Object) {
 
     case getCurrentRoleAuthorizations.case(action.type): {
       return getCurrentRoleAuthorizationsReducer(state, action);
+    }
+
+    case getDataSetKeys.case(action.type): {
+      return getDataSetKeysReducer(state, action);
     }
 
     case getDataSetPermissions.case(action.type): {

--- a/src/core/permissions/sagas/getCurrentDataSetAuthorizations.js
+++ b/src/core/permissions/sagas/getCurrentDataSetAuthorizations.js
@@ -5,16 +5,18 @@
 import {
   call,
   put,
+  select,
   takeEvery,
 } from '@redux-saga/core/effects';
-import { List, Map } from 'immutable';
+import { List, Map, Set } from 'immutable';
 import { Models } from 'lattice';
 import {
   AuthorizationsApiActions,
   AuthorizationsApiSagas,
 } from 'lattice-sagas';
-import { Logger } from 'lattice-utils';
+import { Logger, ReduxUtils } from 'lattice-utils';
 import type { Saga } from '@redux-saga/core';
+import type { EntitySet, EntityType, UUID } from 'lattice';
 import type { WorkerResponse } from 'lattice-sagas';
 import type { SequenceAction } from 'redux-reqseq';
 
@@ -27,27 +29,61 @@ const { AccessCheck, AccessCheckBuilder } = Models;
 const { getAuthorizations } = AuthorizationsApiActions;
 const { getAuthorizationsWorker } = AuthorizationsApiSagas;
 
+const { selectEntitySets, selectEntityTypes } = ReduxUtils;
+
 function* getCurrentDataSetAuthorizationsWorker(action :SequenceAction) :Saga<WorkerResponse> {
 
   let workerResponse :WorkerResponse;
 
   try {
     yield put(getCurrentDataSetAuthorizations.request(action.id, action.value));
-    const { aclKey, permissions } = action.value;
+    const { aclKey, permissions, withProperties } = action.value;
 
-    const accessChecks :AccessCheck[] = [
-      (new AccessCheckBuilder())
-        .setAclKey(aclKey)
-        .setPermissions(permissions)
-        .build()
-    ];
+    let entitySets :Map<UUID, EntitySet> = Map();
+    let entityTypes :Map<UUID, EntityType> = Map();
+    if (withProperties) {
+      entitySets = yield select(selectEntitySets(aclKey));
+      entityTypes = yield select(
+        selectEntityTypes(
+          entitySets.valueSeq().map((entitySet :EntitySet) => entitySet.entityTypeId)
+        )
+      );
+    }
+
+    const keys :List<List<UUID>> = List().withMutations((mutableKeys :List<List<UUID>>) => {
+
+      Set(aclKey).forEach((id :UUID) => {
+        mutableKeys.push(List([id]));
+      });
+
+      if (withProperties) {
+        entitySets.forEach((entitySet :EntitySet, entitySetId :UUID) => {
+          const entityType :EntityType = entityTypes.get(entitySet.entityTypeId);
+          entityType.properties.forEach((propertyTypeId :UUID) => {
+            mutableKeys.push(List([entitySetId, propertyTypeId]));
+          });
+        });
+      }
+    });
+
+    const accessChecks :AccessCheck[] = [];
+    keys.forEach((key) => {
+      accessChecks.push(
+        (new AccessCheckBuilder())
+          .setAclKey(key)
+          .setPermissions(permissions)
+          .build()
+      );
+    });
+
     const response :WorkerResponse = yield call(getAuthorizationsWorker, getAuthorizations(accessChecks));
     if (response.error) throw response.error;
-    const authorization :AuthorizationObject = response.data[0];
-
-    workerResponse = {
-      data: Map([[List(authorization.aclKey), authorization.permissions]])
-    };
+    const data = Map().withMutations((mutableMap) => {
+      response.data.forEach((authorization :AuthorizationObject) => {
+        mutableMap.set(List(authorization.aclKey), authorization.permissions);
+      });
+    });
+    workerResponse = { data };
     yield put(getCurrentDataSetAuthorizations.success(action.id, workerResponse.data));
   }
   catch (error) {

--- a/src/core/permissions/sagas/getCurrentDataSetAuthorizations.js
+++ b/src/core/permissions/sagas/getCurrentDataSetAuthorizations.js
@@ -5,7 +5,6 @@
 import {
   call,
   put,
-  select,
   takeEvery,
 } from '@redux-saga/core/effects';
 import { List, Map, Set } from 'immutable';
@@ -14,13 +13,18 @@ import {
   AuthorizationsApiActions,
   AuthorizationsApiSagas,
 } from 'lattice-sagas';
-import { Logger, ReduxUtils } from 'lattice-utils';
+import { Logger } from 'lattice-utils';
 import type { Saga } from '@redux-saga/core';
-import type { EntitySet, EntityType, UUID } from 'lattice';
 import type { WorkerResponse } from 'lattice-sagas';
 import type { SequenceAction } from 'redux-reqseq';
 
-import { GET_CURRENT_DATA_SET_AUTHORIZATIONS, getCurrentDataSetAuthorizations } from '../actions';
+import { getDataSetKeysWorker } from './getDataSetKeys';
+
+import {
+  GET_CURRENT_DATA_SET_AUTHORIZATIONS,
+  getCurrentDataSetAuthorizations,
+  getDataSetKeys
+} from '../actions';
 import type { AuthorizationObject } from '../../../types';
 
 const LOG = new Logger('PermissionsSagas');
@@ -29,60 +33,48 @@ const { AccessCheck, AccessCheckBuilder } = Models;
 const { getAuthorizations } = AuthorizationsApiActions;
 const { getAuthorizationsWorker } = AuthorizationsApiSagas;
 
-const { selectEntitySets, selectEntityTypes } = ReduxUtils;
-
 function* getCurrentDataSetAuthorizationsWorker(action :SequenceAction) :Saga<WorkerResponse> {
 
   let workerResponse :WorkerResponse;
 
   try {
     yield put(getCurrentDataSetAuthorizations.request(action.id, action.value));
-    const { aclKey, permissions, withProperties } = action.value;
+    const {
+      aclKey,
+      organizationId,
+      permissions,
+      withProperties
+    } = action.value;
+    const keysResponse :WorkerResponse = yield call(getDataSetKeysWorker, getDataSetKeys({
+      atlasDataSetIds: Set(aclKey),
+      entitySetIds: Set(aclKey),
+      organizationId,
+      withProperties,
+    }));
+    if (keysResponse.error) throw keysResponse.error;
 
-    let entitySets :Map<UUID, EntitySet> = Map();
-    let entityTypes :Map<UUID, EntityType> = Map();
-    if (withProperties) {
-      entitySets = yield select(selectEntitySets(aclKey));
-      entityTypes = yield select(
-        selectEntityTypes(
-          entitySets.valueSeq().map((entitySet :EntitySet) => entitySet.entityTypeId)
-        )
-      );
-    }
+    const { keys } = keysResponse.data;
 
-    const keys :List<List<UUID>> = List().withMutations((mutableKeys :List<List<UUID>>) => {
-
-      Set(aclKey).forEach((id :UUID) => {
-        mutableKeys.push(List([id]));
+    let data = {};
+    if (!keys.isEmpty()) {
+      const accessChecks :AccessCheck[] = [];
+      keys.forEach((key) => {
+        accessChecks.push(
+          (new AccessCheckBuilder())
+            .setAclKey(key)
+            .setPermissions(permissions)
+            .build()
+        );
       });
 
-      if (withProperties) {
-        entitySets.forEach((entitySet :EntitySet, entitySetId :UUID) => {
-          const entityType :EntityType = entityTypes.get(entitySet.entityTypeId);
-          entityType.properties.forEach((propertyTypeId :UUID) => {
-            mutableKeys.push(List([entitySetId, propertyTypeId]));
-          });
+      const response :WorkerResponse = yield call(getAuthorizationsWorker, getAuthorizations(accessChecks));
+      if (response.error) throw response.error;
+      data = Map().withMutations((mutableMap) => {
+        response.data.forEach((authorization :AuthorizationObject) => {
+          mutableMap.set(List(authorization.aclKey), authorization.permissions);
         });
-      }
-    });
-
-    const accessChecks :AccessCheck[] = [];
-    keys.forEach((key) => {
-      accessChecks.push(
-        (new AccessCheckBuilder())
-          .setAclKey(key)
-          .setPermissions(permissions)
-          .build()
-      );
-    });
-
-    const response :WorkerResponse = yield call(getAuthorizationsWorker, getAuthorizations(accessChecks));
-    if (response.error) throw response.error;
-    const data = Map().withMutations((mutableMap) => {
-      response.data.forEach((authorization :AuthorizationObject) => {
-        mutableMap.set(List(authorization.aclKey), authorization.permissions);
       });
-    });
+    }
     workerResponse = { data };
     yield put(getCurrentDataSetAuthorizations.success(action.id, workerResponse.data));
   }

--- a/src/core/permissions/sagas/getDataSetKeys.js
+++ b/src/core/permissions/sagas/getDataSetKeys.js
@@ -1,0 +1,125 @@
+/*
+ * @flow
+ */
+
+import {
+  call,
+  put,
+  select,
+  takeEvery,
+} from '@redux-saga/core/effects';
+import {
+  List,
+  Map,
+  Set,
+  get,
+} from 'immutable';
+import { Logger, ReduxUtils } from 'lattice-utils';
+import type { Saga } from '@redux-saga/core';
+import type { EntitySet, EntityType, UUID } from 'lattice';
+import type { WorkerResponse } from 'lattice-sagas';
+import type { SequenceAction } from 'redux-reqseq';
+
+import { getOrSelectDataSets } from '../../edm/actions';
+import { getOrSelectDataSetsWorker } from '../../edm/sagas';
+import { selectAtlasDataSets } from '../../redux/selectors';
+import { GET_DATA_SET_KEYS, getDataSetKeys } from '../actions';
+
+const { selectEntitySets, selectEntityTypes } = ReduxUtils;
+
+const LOG = new Logger('PermissionsSagas');
+
+function* getDataSetKeysWorker(action :SequenceAction) :Saga<WorkerResponse> {
+
+  let workerResponse :WorkerResponse;
+
+  try {
+    yield put(getDataSetKeys.request(action.id, action.value));
+
+    const {
+      atlasDataSetIds,
+      entitySetIds,
+      organizationId,
+      withProperties = false,
+    } :{|
+      atlasDataSetIds :Set<UUID>;
+      entitySetIds :Set<UUID>;
+      organizationId :UUID;
+      withProperties :boolean;
+    |} = action.value;
+
+    // NOTE: call getOrSelectDataSets() to populate redux store
+    yield call(getOrSelectDataSetsWorker, getOrSelectDataSets({
+      atlasDataSetIds,
+      entitySetIds,
+      organizationId,
+    }));
+
+    let atlasDataSets :Map<UUID, Map> = Map();
+    let entitySets :Map<UUID, EntitySet> = Map();
+    let entityTypes :Map<UUID, EntityType> = Map();
+    if (withProperties) {
+      atlasDataSets = yield select(selectAtlasDataSets(atlasDataSetIds));
+      entitySets = yield select(selectEntitySets(entitySetIds));
+
+      entityTypes = yield select(
+        selectEntityTypes(
+          entitySets.valueSeq().map((entitySet :EntitySet) => entitySet.entityTypeId)
+        )
+      );
+    }
+
+    const keys :List<List<UUID>> = List().withMutations((mutableKeys :List<List<UUID>>) => {
+
+      if (!atlasDataSets.isEmpty()) {
+        Set(atlasDataSetIds).forEach((id :UUID) => {
+          mutableKeys.push(List([id]));
+        });
+      }
+
+      if (!entitySets.isEmpty()) {
+        Set(entitySetIds).forEach((id :UUID) => {
+          mutableKeys.push(List([id]));
+        });
+      }
+
+      if (withProperties) {
+        atlasDataSets.forEach((atlasDataSet :Map, atlasDataSetId :UUID) => {
+          get(atlasDataSet, 'columns', List()).forEach((column :Map) => {
+            mutableKeys.push(List([atlasDataSetId, get(column, 'id')]));
+          });
+        });
+        entitySets.forEach((entitySet :EntitySet, entitySetId :UUID) => {
+          const entityType :EntityType = entityTypes.get(entitySet.entityTypeId);
+          entityType.properties.forEach((propertyTypeId :UUID) => {
+            mutableKeys.push(List([entitySetId, propertyTypeId]));
+          });
+        });
+      }
+    });
+
+    workerResponse = { data: { keys } };
+
+    yield put(getDataSetKeys.success(action.id));
+  }
+  catch (error) {
+    workerResponse = { error };
+    LOG.error(action.type, error);
+    yield put(getDataSetKeys.failure(action.id, error));
+  }
+  finally {
+    yield put(getDataSetKeys.finally(action.id));
+  }
+
+  return workerResponse;
+}
+
+function* getDataSetKeysWatcher() :Saga<*> {
+
+  yield takeEvery(GET_DATA_SET_KEYS, getDataSetKeysWorker);
+}
+
+export {
+  getDataSetKeysWatcher,
+  getDataSetKeysWorker,
+};

--- a/src/core/permissions/sagas/index.js
+++ b/src/core/permissions/sagas/index.js
@@ -5,6 +5,7 @@
 export * from './assignPermissionsToDataSet';
 export * from './getCurrentDataSetAuthorizations';
 export * from './getCurrentRoleAuthorizations';
+export * from './getDataSetKeys';
 export * from './getDataSetPermissions';
 export * from './getOrgDataSetObjectPermissions';
 export * from './getOrgObjectPermissions';

--- a/src/core/sagas/Sagas.js
+++ b/src/core/sagas/Sagas.js
@@ -95,6 +95,7 @@ export default function* sagas() :Saga<*> {
     fork(PermissionsSagas.assignPermissionsToDataSetWatcher),
     fork(PermissionsSagas.getCurrentDataSetAuthorizationsWatcher),
     fork(PermissionsSagas.getCurrentRoleAuthorizationsWatcher),
+    fork(PermissionsSagas.getDataSetKeysWatcher),
     fork(PermissionsSagas.getDataSetPermissionsWatcher),
     fork(PermissionsSagas.getOrgDataSetObjectPermissionsWatcher),
     fork(PermissionsSagas.getOrgObjectPermissionsWatcher),


### PR DESCRIPTION
- Updates to show locks instead of checkboxes where the user does not have the proper permissions to view or modify. 
- Updates were made to `PermissionsPanel` in `Role` and `People` view.
- Updates were made to `ObjectPermissionsCard` in the `Object Permissions` view.
- Tooltip with text 'Unauthorized to view permissions' was added to lock for clarity.
##
## Unauthorized
![Screen Shot 2021-02-03 at 5 29 17 PM](https://user-images.githubusercontent.com/19995069/106832261-2d60e200-6646-11eb-824e-0c13671ca5f6.png)
![Screen Shot 2021-02-03 at 5 28 45 PM](https://user-images.githubusercontent.com/19995069/106832218-1a4e1200-6646-11eb-8f0b-a0d5ef3bbaaf.png)
![Screen Shot 2021-02-03 at 5 29 02 PM](https://user-images.githubusercontent.com/19995069/106832246-25a13d80-6646-11eb-945a-758ef86cc0e4.png)
![Screen Shot 2021-02-03 at 5 29 48 PM](https://user-images.githubusercontent.com/19995069/106832287-3782e080-6646-11eb-9eee-e03afa202339.png)


## Authorized
![Screen Shot 2021-02-03 at 5 31 02 PM](https://user-images.githubusercontent.com/19995069/106832331-48335680-6646-11eb-8faf-98b058f2999f.png)
![Screen Shot 2021-02-03 at 5 30 22 PM](https://user-images.githubusercontent.com/19995069/106832336-49fd1a00-6646-11eb-830e-cfb291da3fc5.png)
![Screen Shot 2021-02-03 at 5 31 27 PM](https://user-images.githubusercontent.com/19995069/106832344-4ff2fb00-6646-11eb-84b7-99ceb30f4ebf.png)
